### PR TITLE
fix: make vault and token id params updatable on vault factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "vault_factory"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vault_factory"
-version = "1.0.2"
-authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
+version = "1.0.3"
+authors = ["kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>"]
 edition = "2021"
 description = "Contract to facilitate the vault network"
 license = "MIT"

--- a/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
@@ -49,6 +49,22 @@
                 "string",
                 "null"
               ]
+            },
+            "token_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "vault_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
             }
           }
         }

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
@@ -40,7 +40,9 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::UpdateConfig {
             owner,
             fee_collector_addr,
-        } => update_config(deps, info, owner, fee_collector_addr),
+            vault_id,
+            token_id,
+        } => update_config(deps, info, owner, fee_collector_addr, vault_id, token_id),
     }
 }
 

--- a/packages/vault-network/src/vault_factory.rs
+++ b/packages/vault-network/src/vault_factory.rs
@@ -32,6 +32,8 @@ pub enum ExecuteMsg {
     UpdateConfig {
         owner: Option<String>,
         fee_collector_addr: Option<String>,
+        vault_id: Option<u64>,
+        token_id: Option<u64>,
     },
 }
 


### PR DESCRIPTION
## Description and Motivation

The vault factory uses a token and a vault code id to create vaults. However, those parameters are not modifiable once the vault factory is created, so if you migrate the vault or token contract you basically need to create a new vault for that, which isn't optimal.

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

## Related Issues
#41 
<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
