### PR TITLE
fix: fee_collector schemas generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "contracts/liquidity_hub/pool-network/terraswap_router",
     "contracts/liquidity_hub/pool-network/terraswap_token",
     "contracts/liquidity_hub/fee_collector",
-    "contracts/liquidity_hub/vault-network/vault_factory/",
+    "contracts/liquidity_hub/vault-network/vault_factory",
     "contracts/liquidity_hub/vault-network/vault",
     "contracts/liquidity_hub/vault-network/*",
 ]

--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -6,11 +6,11 @@ projectRootPath=$(realpath "$0" | sed 's|\(.*\)/.*|\1|' | cd ../ | pwd)
 # Generates schemas for contracts in the liquidity_hub
 for component in "$projectRootPath"/contracts/liquidity_hub/*/; do
   echo "Generating schemas for $(basename $component)..."
-  if [[ "$(basename $component)" == "fee-collector" ]]; then
-    cd $component && cargo schema
+  if [[ "$(basename $component)" == "fee_collector" ]]; then
+    cd $component && cargo schema --locked
   else
     for contract in "$component"*/; do
-      cd $contract && cargo schema
+      cd $contract && cargo schema --locked
     done
   fi
 done


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This fixes the bug for generating the schemas for the fee collector contract. Turns out the label being checked was wrong.

## Related Issues

#36 
<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
