### PR TITLE
ci: add script to check wasm artifacts size

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -8,3 +8,6 @@ docker run --rm -v "$projectRootPath":/code \
   --mount type=volume,source="$(basename "$projectRootPath")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/workspace-optimizer:0.12.6
+
+# Check generated wasm file sizes
+$projectRootPath/scripts/check_artifacts_size.sh

--- a/scripts/check_artifacts_size.sh
+++ b/scripts/check_artifacts_size.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Maximum wasm file size
+if [[ -z $1 ]]; then
+  # Default max file size
+  maximumSize=600
+else
+  maximumSize=$1
+fi
+
+echo -e "\nChecking generated wasm artifacts file size..."
+for artifact in artifacts/*.wasm; do
+  artifactSize=$(du -k "$artifact" | cut -f 1)
+  if [ "$artifactSize" -gt $maximumSize ]; then
+    echo "Artifact $(basename $artifact) file size exceeded. Found $artifactSize kB, maximum $maximumSize kB"
+    exit 1
+  fi
+done
+echo -e "All good!\n"


### PR DESCRIPTION
## Description and Motivation

This PR adds a script to check the generated wasm artifact files size, fails if it goes above the given threshold, default 600 kB. The script runs after generated the wasm files with `scripts/build_release.sh`

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

## Related Issues
#40 
<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
