### PR TITLE
feat: migrate vaults from vault factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "vault_factory"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault_factory"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>"]
 edition = "2021"
 description = "Contract to facilitate the vault network"

--- a/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
@@ -29,6 +29,35 @@
       "additionalProperties": false
     },
     {
+      "description": "Migrates vaults to the given code_id. If a [vault_addr] is provided, then migrates only that vault.",
+      "type": "object",
+      "required": [
+        "migrate_vaults"
+      ],
+      "properties": {
+        "migrate_vaults": {
+          "type": "object",
+          "required": [
+            "vault_code_id"
+          ],
+          "properties": {
+            "vault_addr": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vault_code_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Updates the configuration of the vault factory. If a field is not specified, it will not be modified.",
       "type": "object",
       "required": [

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
@@ -4,7 +4,7 @@ use semver::Version;
 use vault_network::vault_factory::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 use crate::err::{StdResult, VaultFactoryError};
-use crate::execute::{create_vault, update_config};
+use crate::execute::{create_vault, migrate_vaults, update_config};
 use crate::queries::{get_config, get_vault, get_vaults};
 use crate::state::{Config, CONFIG};
 
@@ -37,6 +37,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::CreateVault { asset_info, fees } => {
             create_vault(deps, env, info, asset_info, fees)
         }
+        ExecuteMsg::MigrateVaults {
+            vault_addr,
+            vault_code_id,
+        } => migrate_vaults(deps, info, vault_addr, vault_code_id),
         ExecuteMsg::UpdateConfig {
             owner,
             fee_collector_addr,

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/migrate_vaults.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/migrate_vaults.rs
@@ -1,0 +1,241 @@
+use cosmwasm_std::{to_binary, Addr, CosmosMsg, DepsMut, MessageInfo, Response, WasmMsg};
+
+use vault_network::vault::MigrateMsg;
+
+use crate::state::read_vaults;
+use crate::{
+    err::{StdResult, VaultFactoryError},
+    state::CONFIG,
+};
+
+pub fn migrate_vaults(
+    deps: DepsMut,
+    info: MessageInfo,
+    vault_addr: Option<String>,
+    vault_code_id: u64,
+) -> StdResult<Response> {
+    // check that owner is creating vault
+    let config = CONFIG.load(deps.storage)?;
+    if config.owner != info.sender {
+        return Err(VaultFactoryError::Unauthorized {});
+    }
+
+    // migrate only the provided vault address, otherwise migrate all vaults
+    let mut res = Response::new().add_attributes(vec![
+        ("method", "migrate_vaults".to_string()),
+        ("code_id", vault_code_id.to_string()),
+    ]);
+    return if let Some(vault_addr) = vault_addr {
+        Ok(res
+            .add_attribute("vault", vault_addr.clone())
+            .add_message(migrate_vault_msg(
+                deps.api.addr_validate(vault_addr.as_str())?,
+                vault_code_id,
+            )?))
+    } else {
+        let vaults = read_vaults(deps.storage, deps.api, None, Some(30u32))?;
+        for vault in vaults {
+            res = res
+                .add_attribute("vault", &vault.clone().vault)
+                .add_message(migrate_vault_msg(
+                    deps.api.addr_validate(vault.vault.as_str())?,
+                    vault_code_id,
+                )?)
+        }
+
+        Ok(res)
+    };
+}
+
+/// Creates a migrate vault message given a vault address and code id
+fn migrate_vault_msg(vault_addr: Addr, code_id: u64) -> StdResult<CosmosMsg> {
+    Ok(CosmosMsg::Wasm(WasmMsg::Migrate {
+        contract_addr: vault_addr.to_string(),
+        new_code_id: code_id,
+        msg: to_binary(&MigrateMsg {})?,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{testing::mock_info, Addr, Attribute};
+    use cw_multi_test::Executor;
+
+    use crate::tests::store_code::store_vault_code;
+    use crate::{
+        contract::execute,
+        err::VaultFactoryError,
+        tests::{
+            get_fees, mock_app, mock_creator,
+            mock_instantiate::{app_mock_instantiate, mock_instantiate},
+        },
+    };
+
+    #[test]
+    fn cannot_migrate_vault_unauthorized() {
+        let (mut deps, env) = mock_instantiate(5, 6);
+
+        // migrate a vault unauthorized
+        let bad_actor = mock_info("not_owner", &[]);
+
+        let res = execute(
+            deps.as_mut(),
+            env,
+            bad_actor,
+            vault_network::vault_factory::ExecuteMsg::MigrateVaults {
+                vault_addr: None,
+                vault_code_id: 7,
+            },
+        );
+
+        assert_eq!(res.unwrap_err(), VaultFactoryError::Unauthorized {})
+    }
+
+    #[test]
+    fn can_migrate_single_vault() {
+        let (mut deps, env) = mock_instantiate(5, 6);
+        let creator = mock_creator();
+        // migrate a vault unauthorized
+        let info = mock_info(creator.sender.as_str(), &[]);
+
+        let res = execute(
+            deps.as_mut(),
+            env,
+            info,
+            vault_network::vault_factory::ExecuteMsg::MigrateVaults {
+                vault_addr: Some("outdated_vault".to_string()),
+                vault_code_id: 7,
+            },
+        )
+        .unwrap();
+
+        let expected_attributes = vec![
+            Attribute {
+                key: "method".to_string(),
+                value: "migrate_vaults".to_string(),
+            },
+            Attribute {
+                key: "code_id".to_string(),
+                value: "7".to_string(),
+            },
+            Attribute {
+                key: "vault".to_string(),
+                value: "outdated_vault".to_string(),
+            },
+        ];
+
+        assert_eq!(res.attributes, expected_attributes);
+    }
+
+    #[test]
+    fn can_migrate_multiple_vaults() {
+        let mut app = mock_app();
+        let creator = mock_creator();
+
+        let factory_addr = app_mock_instantiate(&mut app);
+        let new_vault_code_id = store_vault_code(&mut app);
+
+        // create two vaults
+        let asset_info_1 = terraswap::asset::AssetInfo::NativeToken {
+            denom: "uluna".to_string(),
+        };
+
+        app.execute_contract(
+            creator.sender.clone(),
+            factory_addr.clone(),
+            &vault_network::vault_factory::ExecuteMsg::CreateVault {
+                asset_info: asset_info_1.clone(),
+                fees: get_fees(),
+            },
+            &[],
+        )
+        .unwrap();
+
+        // get vault address
+        let vault_addr_1: Option<Addr> = app
+            .wrap()
+            .query_wasm_smart(
+                factory_addr.clone(),
+                &vault_network::vault_factory::QueryMsg::Vault {
+                    asset_info: asset_info_1.clone(),
+                },
+            )
+            .unwrap();
+
+        let asset_info_2 = terraswap::asset::AssetInfo::NativeToken {
+            denom: "ujuno".to_string(),
+        };
+
+        app.execute_contract(
+            creator.sender.clone(),
+            factory_addr.clone(),
+            &vault_network::vault_factory::ExecuteMsg::CreateVault {
+                asset_info: asset_info_2.clone(),
+                fees: get_fees(),
+            },
+            &[],
+        )
+        .unwrap();
+
+        // get vault address
+        let vault_addr_2: Option<Addr> = app
+            .wrap()
+            .query_wasm_smart(
+                factory_addr.clone(),
+                &vault_network::vault_factory::QueryMsg::Vault {
+                    asset_info: asset_info_2.clone(),
+                },
+            )
+            .unwrap();
+
+        // migrate vaults
+        let res = app
+            .execute_contract(
+                creator.sender.clone(),
+                factory_addr.clone(),
+                &vault_network::vault_factory::ExecuteMsg::MigrateVaults {
+                    vault_addr: None,
+                    vault_code_id: new_vault_code_id.clone(),
+                },
+                &[],
+            )
+            .unwrap();
+
+        assert_eq!(res.events.len(), 4);
+
+        for event in res.events {
+            if event.ty == "wasm" {
+                let expected_attributes = vec![
+                    Attribute {
+                        key: "_contract_addr".to_string(),
+                        value: factory_addr.clone().to_string(),
+                    },
+                    Attribute {
+                        key: "method".to_string(),
+                        value: "migrate_vaults".to_string(),
+                    },
+                    Attribute {
+                        key: "code_id".to_string(),
+                        value: new_vault_code_id.to_string(),
+                    },
+                    Attribute {
+                        key: "vault".to_string(),
+                        value: vault_addr_2
+                            .clone()
+                            .unwrap_or(Addr::unchecked(""))
+                            .to_string(),
+                    },
+                    Attribute {
+                        key: "vault".to_string(),
+                        value: vault_addr_1
+                            .clone()
+                            .unwrap_or(Addr::unchecked(""))
+                            .to_string(),
+                    },
+                ];
+
+                assert_eq!(event.attributes, expected_attributes);
+            }
+        }
+    }
+}

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/mod.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/mod.rs
@@ -1,5 +1,7 @@
 mod create_vault;
+mod migrate_vaults;
 mod update_config;
 
 pub use create_vault::create_vault;
+pub use migrate_vaults::migrate_vaults;
 pub use update_config::update_config;

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/tests/store_code.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/tests/store_code.rs
@@ -35,7 +35,8 @@ pub fn store_vault_code(app: &mut App) -> u64 {
             vault::contract::instantiate,
             vault::contract::query,
         )
-        .with_reply(vault::reply::reply),
+        .with_reply(vault::reply::reply)
+        .with_migrate(vault::contract::migrate),
     );
 
     app.store_code(contract)

--- a/packages/vault-network/src/vault_factory.rs
+++ b/packages/vault-network/src/vault_factory.rs
@@ -27,6 +27,12 @@ pub enum ExecuteMsg {
         asset_info: AssetInfo,
         fees: VaultFee,
     },
+    /// Migrates vaults to the given code_id. If a [vault_addr] is provided, then migrates only that
+    /// vault.
+    MigrateVaults {
+        vault_addr: Option<String>,
+        vault_code_id: u64,
+    },
     /// Updates the configuration of the vault factory.
     /// If a field is not specified, it will not be modified.
     UpdateConfig {


### PR DESCRIPTION
## Description and Motivation

This PR adds a message on the vault factory contract to migrate its vaults. The message allows you to migrate either one (given) vault or all of them.

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

## Related Issues
#49 
<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
