### PR TITLE
Fix re-entrancy attack in vault deposit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "vault"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "cosmwasm-bignumber",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
     "contracts/liquidity_hub/fee_collector",
     "contracts/liquidity_hub/vault-network/vault_factory",
     "contracts/liquidity_hub/vault-network/vault",
-    "contracts/liquidity_hub/vault-network/*",
 ]
 
 [workspace.metadata.dylint]

--- a/contracts/liquidity_hub/vault-network/vault/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
 edition = "2021"
 description = "Contract to handle a single vault that controls an asset"

--- a/contracts/liquidity_hub/vault-network/vault/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/contract.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::{
 use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20QueryMsg, MinterResponse, TokenInfoResponse};
 use semver::Version;
+
 use terraswap::asset::{Asset, AssetInfo};
 use vault_network::vault::{
     Config, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, INSTANTIATE_LP_TOKEN_REPLY_ID,
@@ -133,6 +134,9 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    // initialize the loan counter
+    LOAN_COUNTER.save(deps.storage, &0)?;
+
     let version: Version = CONTRACT_VERSION
         .parse()
         .map_err(|_| StdError::parse_err("Version", "Failed to parse version"))?;
@@ -149,6 +153,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response
     }
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     Ok(Response::default())
 }
 

--- a/contracts/liquidity_hub/vault-network/vault/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/contract.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{StdResult, VaultError},
     execute::{callback, collect_protocol_fees, deposit, flash_loan, receive, update_config},
     queries::{get_config, get_protocol_fees, get_share},
-    state::{ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG},
+    state::{ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG, LOAN_COUNTER},
 };
 
 const CONTRACT_NAME: &str = "vault_factory";
@@ -110,6 +110,9 @@ pub fn instantiate(
             info: msg.asset_info,
         },
     )?;
+
+    // set loan counter to zero
+    LOAN_COUNTER.save(deps.storage, &0)?;
 
     Ok(Response::new()
         .add_attributes(vec![attr("method", "instantiate")])

--- a/contracts/liquidity_hub/vault-network/vault/src/error.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/error.rs
@@ -46,4 +46,7 @@ pub enum VaultError {
 
     #[error("Withdrawals are not enabled")]
     WithdrawsDisabled {},
+
+    #[error("Cannot deposit while flash-loaning")]
+    DepositDuringLoan {},
 }

--- a/contracts/liquidity_hub/vault-network/vault/src/state.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/state.rs
@@ -7,3 +7,6 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const COLLECTED_PROTOCOL_FEES: Item<Asset> = Item::new("collected_protocol_fees");
 pub const ALL_TIME_COLLECTED_PROTOCOL_FEES: Item<Asset> =
     Item::new("all_time_collected_protocol_fees");
+
+// A counter for how many active loans are being performed
+pub const LOAN_COUNTER: Item<u32> = Item::new("loan_counter");

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/update_vault_config.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/update_vault_config.rs
@@ -30,22 +30,12 @@ pub fn update_vault_config(
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{
-        testing::mock_info, to_binary, Addr, Decimal, ReplyOn, Response, StdError, SubMsg, WasmMsg,
-    };
+    use cosmwasm_std::Addr;
     use cw_multi_test::Executor;
 
-    use terraswap::asset::AssetInfo;
-    use vault_network::vault_factory::INSTANTIATE_VAULT_REPLY_ID;
-    use white_whale::fee::{Fee, VaultFee};
-
     use crate::{
-        contract::execute,
         err::VaultFactoryError,
-        tests::{
-            get_fees, mock_app, mock_creator, mock_execute,
-            mock_instantiate::{app_mock_instantiate, mock_instantiate},
-        },
+        tests::{get_fees, mock_app, mock_creator, mock_instantiate::app_mock_instantiate},
     };
 
     #[test]


### PR DESCRIPTION
## Description and Motivation
During a flash-loan, if a user deposits funds, they are able to pay off their loan as well as claim the flash-loaned funds as their own. To solve this, we disable deposits while a user is flash-loaning.

## Related Issues

---
## Checklist:
- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [X] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.
