### PR TITLE
Make Vault NegativeProfit error display current balance

### DIFF
--- a/contracts/liquidity_hub/vault-network/vault/src/error.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/error.rs
@@ -31,10 +31,14 @@ pub enum VaultError {
     ExternalCallback {},
 
     #[error(
-        "Final desired amount of {required_amount} is less than initial balance of {old_balance}"
+        "Final desired amount of {required_amount} is less than current balance of {current_balance} (got {old_balance} -> {current_balance}, want {old_balance} -> {required_amount})"
     )]
     NegativeProfit {
+        /// The balance before the loan occurred
         old_balance: Uint128,
+        /// The current balance of the vault
+        current_balance: Uint128,
+        /// The required return amount for the vault
         required_amount: Uint128,
     },
 

--- a/contracts/liquidity_hub/vault-network/vault/src/execute/callback/after_trade.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/execute/callback/after_trade.rs
@@ -54,6 +54,7 @@ pub fn after_trade(
     if required_amount > new_balance {
         return Err(VaultError::NegativeProfit {
             old_balance,
+            current_balance: new_balance,
             required_amount,
         });
     }
@@ -329,8 +330,9 @@ mod test {
         assert_eq!(
             res,
             VaultError::NegativeProfit {
+                old_balance: Uint128::new(5_000),
+                current_balance: Uint128::new(5_005),
                 required_amount: Uint128::new(5_010),
-                old_balance: Uint128::new(5_000)
             }
         );
     }
@@ -382,8 +384,9 @@ mod test {
         assert_eq!(
             res,
             VaultError::NegativeProfit {
+                old_balance: Uint128::new(5_000),
+                current_balance: Uint128::new(5_005),
                 required_amount: Uint128::new(5_010),
-                old_balance: Uint128::new(5_000)
             }
         );
     }


### PR DESCRIPTION
## Description and Motivation

Currently the error message is unhelpful as it displays the old balance before the loan occurred, and the required amount. It would be helpful for errors if they displayed the balance the contract got to, so we can see the difference between what was received as output, and what was required.

---
## Checklist:

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [X] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.
