### PR TITLE
feat: remove vaults from vault factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "vault_factory"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault_factory"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>"]
 edition = "2021"
 description = "Contract to facilitate the vault network"

--- a/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
@@ -58,7 +58,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Removes a vault given the vault address provided",
+      "description": "Removes a vault given its [AssetInfo]",
       "type": "object",
       "required": [
         "remove_vault"

--- a/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault_factory/schema/execute_msg.json
@@ -58,6 +58,27 @@
       "additionalProperties": false
     },
     {
+      "description": "Removes a vault given the vault address provided",
+      "type": "object",
+      "required": [
+        "remove_vault"
+      ],
+      "properties": {
+        "remove_vault": {
+          "type": "object",
+          "required": [
+            "asset_info"
+          ],
+          "properties": {
+            "asset_info": {
+              "$ref": "#/definitions/AssetInfo"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Updates a vault config",
       "type": "object",
       "required": [

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
@@ -5,7 +5,9 @@ use semver::Version;
 use vault_network::vault_factory::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 use crate::err::{StdResult, VaultFactoryError};
-use crate::execute::{create_vault, migrate_vaults, update_config, update_vault_config};
+use crate::execute::{
+    create_vault, migrate_vaults, remove_vault, update_config, update_vault_config,
+};
 use crate::queries::{get_config, get_vault, get_vaults};
 use crate::state::{Config, CONFIG};
 
@@ -45,6 +47,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             vault_addr,
             vault_code_id,
         } => migrate_vaults(deps, info, vault_addr, vault_code_id),
+        ExecuteMsg::RemoveVault { asset_info } => remove_vault(deps, info, asset_info),
         ExecuteMsg::UpdateConfig {
             owner,
             fee_collector_addr,

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/err.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/err.rs
@@ -23,6 +23,9 @@ pub enum VaultFactoryError {
         new_version: Version,
         current_version: Version,
     },
+
+    #[error("Vault doesn't exist given the vault address provided")]
+    NonExistentVault {},
 }
 
 impl From<semver::Error> for VaultFactoryError {

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/mod.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/mod.rs
@@ -1,9 +1,11 @@
 mod create_vault;
 mod migrate_vaults;
+mod remove_vault;
 mod update_config;
 mod update_vault_config;
 
 pub use create_vault::create_vault;
 pub use migrate_vaults::migrate_vaults;
+pub use remove_vault::remove_vault;
 pub use update_config::update_config;
 pub use update_vault_config::update_vault_config;

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/remove_vault.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/remove_vault.rs
@@ -1,0 +1,138 @@
+use cosmwasm_std::{DepsMut, MessageInfo, Response};
+
+use terraswap::asset::AssetInfo;
+
+use crate::asset::AssetReference;
+use crate::state::VAULTS;
+use crate::{
+    err::{StdResult, VaultFactoryError},
+    state::CONFIG,
+};
+
+pub fn remove_vault(
+    deps: DepsMut,
+    info: MessageInfo,
+    asset_info: AssetInfo,
+) -> StdResult<Response> {
+    let config = CONFIG.load(deps.storage)?;
+    if config.owner != info.sender {
+        return Err(VaultFactoryError::Unauthorized {});
+    }
+
+    if let Ok(None) = VAULTS.may_load(deps.storage, asset_info.get_reference()) {
+        return Err(VaultFactoryError::NonExistentVault {});
+    }
+
+    VAULTS.remove(deps.storage, asset_info.get_reference());
+
+    Ok(Response::new().add_attributes(vec![("method", "remove_vault")]))
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{testing::mock_info, Attribute};
+    use cw_multi_test::Executor;
+
+    use crate::{
+        contract::execute,
+        err::VaultFactoryError,
+        tests::{
+            get_fees, mock_app, mock_creator,
+            mock_instantiate::{app_mock_instantiate, mock_instantiate},
+        },
+    };
+
+    #[test]
+    fn can_remove_vault() {
+        let mut app = mock_app();
+        let creator = mock_creator();
+
+        let factory_addr = app_mock_instantiate(&mut app);
+
+        // create vault
+        let asset_info_1 = terraswap::asset::AssetInfo::NativeToken {
+            denom: "uluna".to_string(),
+        };
+
+        app.execute_contract(
+            creator.sender.clone(),
+            factory_addr.clone(),
+            &vault_network::vault_factory::ExecuteMsg::CreateVault {
+                asset_info: asset_info_1.clone(),
+                fees: get_fees(),
+            },
+            &[],
+        )
+        .unwrap();
+
+        // remove vault
+        let res = app
+            .execute_contract(
+                creator.sender.clone(),
+                factory_addr.clone(),
+                &vault_network::vault_factory::ExecuteMsg::RemoveVault {
+                    asset_info: asset_info_1.clone(),
+                },
+                &[],
+            )
+            .unwrap();
+
+        assert_eq!(res.events.len(), 2);
+
+        for event in res.events {
+            if event.ty == "wasm" {
+                let expected_attributes = vec![
+                    Attribute {
+                        key: "_contract_addr".to_string(),
+                        value: factory_addr.clone().to_string(),
+                    },
+                    Attribute {
+                        key: "method".to_string(),
+                        value: "remove_vault".to_string(),
+                    },
+                ];
+
+                assert_eq!(event.attributes, expected_attributes);
+            }
+        }
+    }
+
+    #[test]
+    fn cannot_remove_vault_unauthorized() {
+        let asset_info = terraswap::asset::AssetInfo::NativeToken {
+            denom: "uluna".to_string(),
+        };
+        let (mut deps, env) = mock_instantiate(5, 6);
+
+        // migrate a vault unauthorized
+        let bad_actor = mock_info("not_owner", &[]);
+
+        let res = execute(
+            deps.as_mut(),
+            env,
+            bad_actor,
+            vault_network::vault_factory::ExecuteMsg::RemoveVault { asset_info },
+        );
+
+        assert_eq!(res.unwrap_err(), VaultFactoryError::Unauthorized {})
+    }
+
+    #[test]
+    fn cannot_remove_vault_non_existent() {
+        let asset_info = terraswap::asset::AssetInfo::NativeToken {
+            denom: "uluna".to_string(),
+        };
+        let (mut deps, env) = mock_instantiate(5, 6);
+        let creator = mock_creator();
+
+        // remove non-existent vault
+        let res = execute(
+            deps.as_mut(),
+            env,
+            creator,
+            vault_network::vault_factory::ExecuteMsg::RemoveVault { asset_info },
+        );
+
+        assert_eq!(res.unwrap_err(), VaultFactoryError::NonExistentVault {})
+    }
+}

--- a/packages/vault-network/src/vault_factory.rs
+++ b/packages/vault-network/src/vault_factory.rs
@@ -34,6 +34,8 @@ pub enum ExecuteMsg {
         vault_addr: Option<String>,
         vault_code_id: u64,
     },
+    /// Removes a vault given the vault address provided
+    RemoveVault { asset_info: AssetInfo },
     /// Updates a vault config
     UpdateVaultConfig {
         vault_addr: String,

--- a/packages/vault-network/src/vault_factory.rs
+++ b/packages/vault-network/src/vault_factory.rs
@@ -34,7 +34,7 @@ pub enum ExecuteMsg {
         vault_addr: Option<String>,
         vault_code_id: u64,
     },
-    /// Removes a vault given the vault address provided
+    /// Removes a vault given its [AssetInfo]
     RemoveVault { asset_info: AssetInfo },
     /// Updates a vault config
     UpdateVaultConfig {


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR adds a message on the vault factory contract to remove vaults added to the vault directory. This way, in case wrong vaults are added, they can be removed and keep the vault directory clean.
Implemented `ExecuteMsg::RemoveVault` in a slightly different way than requested in [Issue #52](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues/52):
I decided to use AssetInfo instead of the vault address as vault identifier because AssetInfo is the key for the Vaults Map.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->
#52 

---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
