### PR TITLE
ci: add uni-5 to deployment script

### DIFF
--- a/scripts/deployment/deploy_env/testnets/juno.env
+++ b/scripts/deployment/deploy_env/testnets/juno.env
@@ -1,4 +1,4 @@
-export CHAIN_ID="uni-3"
+export CHAIN_ID="uni-5"
 export DENOM="ujunox"
 export BINARY="junod"
 export RPC="https://juno-testnet-rpc.polkachu.com:443"

--- a/scripts/deployment/deploy_liquidity_hub.sh
+++ b/scripts/deployment/deploy_liquidity_hub.sh
@@ -70,9 +70,14 @@ esac
 
 source <(cat "$projectRootPath"/scripts/deployment/deploy_env/base.env)
 
-deployer='deployer_wallet'
 # import the deployer wallet
-export mnemonic=$(cat "$projectRootPath"/scripts/deployment/deploy_env/mnemonics/deployer_mnemonic.txt)
+if [[ "$(echo ${chain##*-})" = "testnet" ]] ; then
+  deployer='deployer_wallet_testnet'
+  export mnemonic=$(cat "$projectRootPath"/scripts/deployment/deploy_env/mnemonics/deployer_mnemonic_testnet.txt)
+else
+  deployer='deployer_wallet'
+  export mnemonic=$(cat "$projectRootPath"/scripts/deployment/deploy_env/mnemonics/deployer_mnemonic.txt)
+fi
 
 # verify if the deployer wallet has already been imported
 if ! $BINARY keys show $deployer >/dev/null 2>&1; then


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

Juno testnet uni-3 was shut down. uni-5 is the latest one, so this fixes the deployment script.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
