### PR TITLE
refactor: owner validation for vault factory contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "vault_factory"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault_factory"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>"]
 edition = "2021"
 description = "Contract to facilitate the vault network"

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
@@ -36,24 +36,28 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    // permission check
+    let config = CONFIG.load(deps.storage)?;
+    if config.owner != info.sender {
+        return Err(VaultFactoryError::Unauthorized {});
+    }
+
     match msg {
-        ExecuteMsg::CreateVault { asset_info, fees } => {
-            create_vault(deps, env, info, asset_info, fees)
-        }
+        ExecuteMsg::CreateVault { asset_info, fees } => create_vault(deps, env, asset_info, fees),
         ExecuteMsg::UpdateVaultConfig { vault_addr, params } => {
-            update_vault_config(deps, info, vault_addr, params)
+            update_vault_config(deps, vault_addr, params)
         }
         ExecuteMsg::MigrateVaults {
             vault_addr,
             vault_code_id,
-        } => migrate_vaults(deps, info, vault_addr, vault_code_id),
-        ExecuteMsg::RemoveVault { asset_info } => remove_vault(deps, info, asset_info),
+        } => migrate_vaults(deps, vault_addr, vault_code_id),
+        ExecuteMsg::RemoveVault { asset_info } => remove_vault(deps, asset_info),
         ExecuteMsg::UpdateConfig {
             owner,
             fee_collector_addr,
             vault_id,
             token_id,
-        } => update_config(deps, info, owner, fee_collector_addr, vault_id, token_id),
+        } => update_config(deps, owner, fee_collector_addr, vault_id, token_id),
     }
 }
 

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg, WasmMsg};
+use cosmwasm_std::{to_binary, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg};
 use terraswap::asset::AssetInfo;
 use vault_network::{vault::InstantiateMsg, vault_factory::INSTANTIATE_VAULT_REPLY_ID};
 use white_whale::fee::VaultFee;
@@ -12,15 +12,11 @@ use crate::{
 pub fn create_vault(
     deps: DepsMut,
     env: Env,
-    info: MessageInfo,
     asset_info: AssetInfo,
     fees: VaultFee,
 ) -> StdResult<Response> {
     // check that owner is creating vault
     let config = CONFIG.load(deps.storage)?;
-    if config.owner != info.sender {
-        return Err(VaultFactoryError::Unauthorized {});
-    }
 
     // check that existing vault does not exist
     let existing_addr = VAULTS.may_load(deps.storage, asset_info.get_reference())?;

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/migrate_vaults.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/migrate_vaults.rs
@@ -1,25 +1,15 @@
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, DepsMut, MessageInfo, Response, WasmMsg};
+use cosmwasm_std::{to_binary, Addr, CosmosMsg, DepsMut, Response, WasmMsg};
 
 use vault_network::vault::MigrateMsg;
 
+use crate::err::StdResult;
 use crate::state::read_vaults;
-use crate::{
-    err::{StdResult, VaultFactoryError},
-    state::CONFIG,
-};
 
 pub fn migrate_vaults(
     deps: DepsMut,
-    info: MessageInfo,
     vault_addr: Option<String>,
     vault_code_id: u64,
 ) -> StdResult<Response> {
-    // check that owner is migrating vault
-    let config = CONFIG.load(deps.storage)?;
-    if config.owner != info.sender {
-        return Err(VaultFactoryError::Unauthorized {});
-    }
-
     // migrate only the provided vault address, otherwise migrate all vaults
     let mut res = Response::new().add_attributes(vec![
         ("method", "migrate_vaults".to_string()),

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/remove_vault.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/remove_vault.rs
@@ -1,24 +1,12 @@
-use cosmwasm_std::{DepsMut, MessageInfo, Response};
+use cosmwasm_std::{DepsMut, Response};
 
 use terraswap::asset::AssetInfo;
 
 use crate::asset::AssetReference;
+use crate::err::{StdResult, VaultFactoryError};
 use crate::state::VAULTS;
-use crate::{
-    err::{StdResult, VaultFactoryError},
-    state::CONFIG,
-};
 
-pub fn remove_vault(
-    deps: DepsMut,
-    info: MessageInfo,
-    asset_info: AssetInfo,
-) -> StdResult<Response> {
-    let config = CONFIG.load(deps.storage)?;
-    if config.owner != info.sender {
-        return Err(VaultFactoryError::Unauthorized {});
-    }
-
+pub fn remove_vault(deps: DepsMut, asset_info: AssetInfo) -> StdResult<Response> {
     if let Ok(None) = VAULTS.may_load(deps.storage, asset_info.get_reference()) {
         return Err(VaultFactoryError::NonExistentVault {});
     }

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/update_config.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/update_config.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{DepsMut, MessageInfo, Response};
+use cosmwasm_std::{DepsMut, Response};
 
 use crate::{
     err::{StdResult, VaultFactoryError},
@@ -7,18 +7,12 @@ use crate::{
 
 pub fn update_config(
     deps: DepsMut,
-    info: MessageInfo,
     new_owner: Option<String>,
     new_fee_collector_addr: Option<String>,
     new_vault_id: Option<u64>,
     new_token_id: Option<u64>,
 ) -> StdResult<Response> {
     let new_config = CONFIG.update::<_, VaultFactoryError>(deps.storage, |mut config| {
-        // check that sender is the owner
-        if info.sender != config.owner {
-            return Err(VaultFactoryError::Unauthorized {});
-        }
-
         if let Some(new_owner) = new_owner {
             config.owner = deps.api.addr_validate(&new_owner)?;
         };

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/update_vault_config.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/update_vault_config.rs
@@ -1,24 +1,14 @@
-use cosmwasm_std::{wasm_execute, DepsMut, MessageInfo, Response};
+use cosmwasm_std::{wasm_execute, DepsMut, Response};
 
 use vault_network::vault::UpdateConfigParams;
 
-use crate::{
-    err::{StdResult, VaultFactoryError},
-    state::CONFIG,
-};
+use crate::err::StdResult;
 
 pub fn update_vault_config(
     deps: DepsMut,
-    info: MessageInfo,
     vault_addr: String,
     params: UpdateConfigParams,
 ) -> StdResult<Response> {
-    // check that owner is executing on the vault
-    let config = CONFIG.load(deps.storage)?;
-    if config.owner != info.sender {
-        return Err(VaultFactoryError::Unauthorized {});
-    }
-
     Ok(Response::new()
         .add_message(wasm_execute(
             deps.api.addr_validate(vault_addr.as_str())?.to_string(),


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->
This PR optimizes the owner validation in the vault factory contract by moving it to the execute entry point instead of having it on each function triggered as described in [Issue #78](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues/78)

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->
#78 

---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
