### PR TITLE
fix(vault): facilitate creating a vault with an ibc token

### DIFF
--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
@@ -43,7 +43,7 @@ pub fn create_vault(
             })?,
             funds: vec![],
             label: format!(
-                "white whale {} vault",
+                "White Whale {} Vault",
                 asset_info.clone().get_label(&deps.as_ref())?
             ),
         }
@@ -115,7 +115,7 @@ mod tests {
                         })
                         .unwrap(),
                         funds: vec![],
-                        label: "white whale uluna vault".to_string()
+                        label: "White Whale uluna Vault".to_string()
                     }
                     .into()
                 })
@@ -297,7 +297,7 @@ mod tests {
                         })
                         .unwrap(),
                         funds: vec![],
-                        label: "white whale ibc/4CD5...3D04 vault".to_string()
+                        label: "White Whale ibc/4CD5...3D04 Vault".to_string()
                     }
                     .into()
                 })


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This fixes creating a vault with an IBC token. This was failing before as the token symbol can't contain either "/" or digits (from the ibc hash). So if an IBC token is used, the symbol "uLP-ibc" is gonna be used.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

#53 

---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
