### PR TITLE
Use Rust 1.64 workspaces

### DIFF
--- a/.github/workflows/ci-test-fmt-check.yaml
+++ b/.github/workflows/ci-test-fmt-check.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0
+          toolchain: 1.64.0
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/pr-convcom-check.yaml
+++ b/.github/workflows/pr-convcom-check.yaml
@@ -1,6 +1,6 @@
 name: Pull request
 # This workflow is triggered on pushes to the repository.
-on: [ pull_request ]
+on: [pull_request]
 
 jobs:
   style:
@@ -16,7 +16,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0
+          toolchain: 1.64.0
           override: true
           components: rustfmt
       - run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,25 +235,14 @@ dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
+ "cw-storage-plus",
+ "cw-utils",
  "derivative",
  "itertools",
  "prost",
  "schemars",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8b264257c4f44c49b7ce09377af63aa040768ecd3fd7bdd2d48a09323a1e90"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -269,27 +258,13 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
-dependencies = [
- "cosmwasm-std",
- "cw2 0.14.0",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-utils"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae0b69fa7679de78825b4edeeec045066aa2b2c4b6e063d80042e565bb4da5c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 0.15.1",
+ "cw2",
  "schemars",
  "semver",
  "serde",
@@ -310,37 +285,13 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa74c324af8e3506fd8d50759a265bead3f87402e413c840042af5d2808463d6"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw2"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5abb8ecea72e09afff830252963cb60faf945ce6cef2c20a43814516082653da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw20"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f446f59c519fbac5ab8b9f6c7f8dcaa05ee761703971406b28221ea778bb737"
-dependencies = [
- "cosmwasm-std",
- "cw-utils 0.14.0",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
@@ -353,26 +304,9 @@ checksum = "f6025276fb6e603e974c21f3e4606982cdc646080e8fba3198816605505e1d9a"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.15.1",
+ "cw-utils",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw20-base"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39bf97c985a50f2e340833137b3f14999f58708c4ca9928cd8f87d530c4109c"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "cw-utils 0.14.0",
- "cw2 0.14.0",
- "cw20 0.14.0",
- "schemars",
- "semver",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -383,10 +317,10 @@ checksum = "0909c56d0c14601fbdc69382189799482799dcad87587926aec1f3aa321abc41"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
- "cw2 0.15.1",
- "cw20 0.15.1",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
+ "cw20",
  "schemars",
  "semver",
  "serde",
@@ -501,9 +435,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 0.15.1",
- "cw2 0.15.1",
- "cw20 0.15.1",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
  "schemars",
  "semver",
  "serde",
@@ -695,15 +629,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -940,8 +865,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw20 0.15.1",
- "protobuf 3.1.0",
+ "cw20",
+ "protobuf",
  "schemars",
  "serde",
  "white-whale",
@@ -954,10 +879,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.14.0",
- "cw2 0.14.0",
- "cw20 0.14.0",
- "protobuf 2.27.1",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
+ "protobuf",
  "schemars",
  "serde",
  "terraswap",
@@ -972,11 +897,11 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.14.0",
- "cw2 0.14.0",
- "cw20 0.14.0",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
  "integer-sqrt",
- "protobuf 2.27.1",
+ "protobuf",
  "schemars",
  "serde",
  "terraswap",
@@ -991,9 +916,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.14.0",
- "cw2 0.14.0",
- "cw20 0.14.0",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
  "integer-sqrt",
  "schemars",
  "serde",
@@ -1007,11 +932,11 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.14.0",
+ "cw-storage-plus",
  "cw0",
- "cw2 0.14.0",
- "cw20 0.14.0",
- "cw20-base 0.14.0",
+ "cw2",
+ "cw20",
+ "cw20-base",
  "schemars",
  "serde",
  "terraswap",
@@ -1070,12 +995,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 0.15.1",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "cw20-base 0.15.1",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
+ "cw20-base",
  "fee_collector",
- "protobuf 3.1.0",
+ "protobuf",
  "schemars",
  "semver",
  "serde",
@@ -1103,12 +1028,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 0.15.1",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "cw20-base 0.15.1",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
+ "cw20-base",
  "fee_collector",
- "protobuf 3.1.0",
+ "protobuf",
  "schemars",
  "semver",
  "serde",
@@ -1126,12 +1051,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 0.15.1",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "cw20-base 0.15.1",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
+ "cw20-base",
  "fee_collector",
- "protobuf 3.1.0",
+ "protobuf",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,9 +80,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cosmwasm-bignumber"
@@ -88,11 +97,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
+checksum = "ce1c26e5595c6a960cd3d6dc1d8629e16a2b0cb22ecd653b28bbf292d7c53a3c"
 dependencies = [
- "digest",
+ "digest 0.10.5",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.3",
@@ -101,33 +110,49 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b36e527620a2a3e00e46b6e731ab6c9b68d11069c986f7d7be8eba79ef081a4"
+checksum = "0a24050753f242554c558dfe7a6b3a456850f2bc6fcf8b518988720e40a5fa21"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772e80bbad231a47a2068812b723a1ff81dd4a0d56c9391ac748177bea3a61da"
+checksum = "9ce6fe57b9e59a87a406b825cbe647f6456e1a853f8d4c99bffcc20957fd29d6"
 dependencies = [
+ "cosmwasm-schema-derive",
  "schemars",
+ "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e8cfc90b557a8ed272c9daf0ff3634e6b9f4698a19832bba6a4c7baa46da04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875994993c2082a6fcd406937bf0fca21c349e4a624f3810253a14fa83a3a195"
+checksum = "78e50ba8bfea2e449be2e7fa96fd8b196d09fb5ef34e27a18f28835ed835b199"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
+ "hex",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -137,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18403b07304d15d304dad11040d45bbcaf78d603b4be3fb5e2685c16f9229b5"
+checksum = "6ce135cec6c90df7115b0f5b2b40683dd41ac62999dfb002107f6a9f5c345374"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,9 +193,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -179,23 +204,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -203,15 +228,15 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca153120cf5b91af88be106b0c6c0263423d959bc813b1592982c02c4691a4ae"
+checksum = "e8e81b4a7821d5eeba0d23f737c16027b39a600742ca8c32eb980895ffd270f4"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
- "cw-utils",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 0.15.1",
  "derivative",
  "itertools",
  "prost",
@@ -232,13 +257,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-storage-plus"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6cf70ef7686e2da9ad7b067c5942cd3e88dd9453f7af42f54557f8af300fb0"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw-utils"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
 dependencies = [
  "cosmwasm-std",
- "cw2",
+ "cw2 0.14.0",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae0b69fa7679de78825b4edeeec045066aa2b2c4b6e063d80042e565bb4da5c"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw2 0.15.1",
  "schemars",
  "semver",
  "serde",
@@ -264,7 +315,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa74c324af8e3506fd8d50759a265bead3f87402e413c840042af5d2808463d6"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.14.0",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abb8ecea72e09afff830252963cb60faf945ce6cef2c20a43814516082653da"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
  "schemars",
  "serde",
 ]
@@ -276,7 +340,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f446f59c519fbac5ab8b9f6c7f8dcaa05ee761703971406b28221ea778bb737"
 dependencies = [
  "cosmwasm-std",
- "cw-utils",
+ "cw-utils 0.14.0",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw20"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6025276fb6e603e974c21f3e4606982cdc646080e8fba3198816605505e1d9a"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 0.15.1",
  "schemars",
  "serde",
 ]
@@ -288,10 +365,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e39bf97c985a50f2e340833137b3f14999f58708c4ca9928cd8f87d530c4109c"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
- "cw20",
+ "cw-storage-plus 0.14.0",
+ "cw-utils 0.14.0",
+ "cw2 0.14.0",
+ "cw20 0.14.0",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-base"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909c56d0c14601fbdc69382189799482799dcad87587926aec1f3aa321abc41"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 0.15.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
  "schemars",
  "semver",
  "serde",
@@ -300,11 +395,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -328,6 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,9 +442,9 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -355,7 +462,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "zeroize",
 ]
@@ -368,16 +475,18 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
+ "digest 0.10.5",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -391,11 +500,10 @@ dependencies = [
  "cosmwasm-bignumber",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus",
- "cw2",
- "cw20",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
  "schemars",
  "semver",
  "serde",
@@ -412,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -460,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -477,12 +585,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -511,15 +618,14 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -551,13 +657,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -651,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -692,10 +797,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",
@@ -766,28 +872,39 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signature"
-version = "1.4.0"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.5",
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
@@ -823,8 +940,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw20",
- "protobuf 2.27.1",
+ "cw20 0.15.1",
+ "protobuf 3.1.0",
  "schemars",
  "serde",
  "white-whale",
@@ -837,9 +954,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
- "cw2",
- "cw20",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "cw20 0.14.0",
  "protobuf 2.27.1",
  "schemars",
  "serde",
@@ -855,9 +972,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
- "cw2",
- "cw20",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "cw20 0.14.0",
  "integer-sqrt",
  "protobuf 2.27.1",
  "schemars",
@@ -874,9 +991,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
- "cw2",
- "cw20",
+ "cw-storage-plus 0.14.0",
+ "cw2 0.14.0",
+ "cw20 0.14.0",
  "integer-sqrt",
  "schemars",
  "serde",
@@ -890,11 +1007,11 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
+ "cw-storage-plus 0.14.0",
  "cw0",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw2 0.14.0",
+ "cw20 0.14.0",
+ "cw20-base 0.14.0",
  "schemars",
  "serde",
  "terraswap",
@@ -953,10 +1070,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "cw20-base 0.15.1",
  "fee_collector",
  "protobuf 3.1.0",
  "schemars",
@@ -986,10 +1103,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "cw20-base 0.15.1",
  "fee_collector",
  "protobuf 3.1.0",
  "schemars",
@@ -1009,10 +1126,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "cw20-base 0.15.1",
  "fee_collector",
  "protobuf 3.1.0",
  "schemars",
@@ -1056,6 +1173,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,39 @@
 [workspace]
 
 members = [
-    "packages/*",
-    "contracts/liquidity_hub/pool-network/terraswap_factory",
-    "contracts/liquidity_hub/pool-network/terraswap_pair",
-    "contracts/liquidity_hub/pool-network/terraswap_router",
-    "contracts/liquidity_hub/pool-network/terraswap_token",
-    "contracts/liquidity_hub/fee_collector",
-    "contracts/liquidity_hub/vault-network/*",
+	"packages/*",
+	"contracts/liquidity_hub/pool-network/terraswap_factory",
+	"contracts/liquidity_hub/pool-network/terraswap_pair",
+	"contracts/liquidity_hub/pool-network/terraswap_router",
+	"contracts/liquidity_hub/pool-network/terraswap_token",
+	"contracts/liquidity_hub/fee_collector",
+	"contracts/liquidity_hub/vault-network/*",
 ]
 
+[workspace.package]
+edition = "2021"
+homepage = "https://whitewhale.money"
+license = "MIT"
+repository = "https://github.com/White-Whale-Defi-Platform/migaloo-core"
+publish = false
+
+[workspace.dependencies]
+cosmwasm-std = { version = "1.0.0", features = ["iterator"] }
+cw2 = "0.15.1"
+cw20 = "0.15.1"
+cw20-base = { version = "0.15.1", features = ["library"] }
+cw-storage-plus = "0.15.1"
+protobuf = { version = "3.1.0", features = ["with-bytes"] }
+schemars = "0.8.3"
+semver = "1.0.12"
+serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+terraswap = { path = "./packages/terraswap" }
+thiserror = "1.0.21"
+vault-network = { path = "./packages/vault-network" }
+white-whale = { path = "./packages/white-whale" }
+
 [workspace.metadata.dylint]
-libraries = [
-    { git = "https://github.com/0xFable/cw-lint" },
-]
+libraries = [{ git = "https://github.com/0xFable/cw-lint" }]
 
 [profile.release]
 rpath = false

--- a/contracts/liquidity_hub/fee_collector/Cargo.toml
+++ b/contracts/liquidity_hub/fee_collector/Cargo.toml
@@ -2,17 +2,18 @@
 name = "fee_collector"
 version = "1.0.2"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
-edition = "2021"
+edition.workspace = true
 description = "Contract to collect the fees accrued by the pools and vaults in the liquidity hub"
-license = "MIT"
-repository = "https://github.com/White-Whale-DeFi-Platform/contracts"
-homepage = "https://whitewhale.money"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 documentation = "https://whitewhale.money"
+publish.workspace = true
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+	# Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+	"contract.wasm",
+	"hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -25,21 +26,20 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = "1.0.0"
-cosmwasm-storage = "1.0.0"
-cw-storage-plus = "0.14.0"
-cw2 = "0.14.0"
-schemars = "0.8.10"
-semver = "1.0.12"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.31" }
-white-whale = { version = "1.0.0", path = "../../../packages/white-whale" }
-terraswap = { version = "2.8.0", path = "../../../packages/terraswap" }
-vault-network = {version = "1.0.0", path = "../../../packages/vault-network" }
+cosmwasm-std.workspace = true
+cw2.workspace = true
+cw-storage-plus.workspace = true
+schemars.workspace = true
+semver.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+white-whale.workspace = true
+terraswap.workspace = true
+vault-network.workspace = true
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.1"
 terraswap-factory = { path = "../pool-network/terraswap_factory" }
 terraswap-pair = { path = "../pool-network/terraswap_pair" }
 terraswap-token = { path = "../pool-network/terraswap_token" }
@@ -47,5 +47,4 @@ terraswap = { version = "2.8.0", path = "../../../packages/terraswap" }
 vault_factory = { version = "1.0.0", path = "../vault-network/vault_factory" }
 vault = { version = "1.0.0", path = "../vault-network/vault" }
 cosmwasm-bignumber = { git = "https://github.com/terra-money/terra-cosmwasm", branch = "feature/wasm-1.0" }
-cw20 = {version = "0.14.0"}
-
+cw20 = { version = "0.15.1" }

--- a/contracts/liquidity_hub/vault-network/vault/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault/Cargo.toml
@@ -2,12 +2,13 @@
 name = "vault"
 version = "1.1.1"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
-edition = "2021"
+edition.workspace = true
 description = "Contract to handle a single vault that controls an asset"
-license = "MIT"
-repository = "https://github.com/White-Whale-DeFi-Platform/migaloo-core"
-homepage = "https://whitewhale.money"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 documentation = "https://whitewhale.money"
+publish.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -16,22 +17,22 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["iterator"] }
-cw2 = "0.14.0"
-cw20 = "0.14.0"
-cw20-base = { version = "0.14.0", features = ["library"] }
-cw-storage-plus = "0.14.0"
-protobuf = { version = "3.1.0", features = ["with-bytes"] }
-schemars = "0.8.3"
-semver = "1.0.12"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-terraswap = { path = "../../../../packages/terraswap" }
-thiserror = "1.0.21"
-vault-network = { path = "../../../../packages/vault-network" }
-white-whale = { path = "../../../../packages/white-whale" }
+cosmwasm-std.workspace = true
+cw2.workspace = true
+cw20.workspace = true
+cw20-base.workspace = true
+cw-storage-plus.workspace = true
+protobuf.workspace = true
+schemars.workspace = true
+semver.workspace = true
+serde.workspace = true
+terraswap.workspace = true
+thiserror.workspace = true
+vault-network.workspace = true
+white-whale.workspace = true
 cosmwasm-bignumber = { git = "https://github.com/terra-money/terra-cosmwasm", branch = "feature/wasm-1.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.1"
 fee_collector = { path = "../../fee_collector" }

--- a/contracts/liquidity_hub/vault-network/vault/schema/execute_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault/schema/execute_msg.json
@@ -101,7 +101,7 @@
   ],
   "definitions": {
     "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
     },
     "CallbackMsg": {

--- a/contracts/liquidity_hub/vault-network/vault/schema/query_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault/schema/query_msg.json
@@ -56,6 +56,27 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Retrieves the [`Uint128`] amount that must be sent back to the contract to pay off a loan taken out, in a [`PaybackAmountResponse`] response.",
+      "type": "object",
+      "required": [
+        "get_payback_amount"
+      ],
+      "properties": {
+        "get_payback_amount": {
+          "type": "object",
+          "required": [
+            "amount"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "vault_factory"
 version = "1.0.7"
-authors = ["kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>"]
-edition = "2021"
+authors = [
+	"kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>",
+]
+edition.workspace = true
 description = "Contract to facilitate the vault network"
-license = "MIT"
-repository = "https://github.com/White-Whale-DeFi-Platform/migaloo-core"
-homepage = "https://whitewhale.money"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 documentation = "https://whitewhale.money"
+publish.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -16,22 +19,22 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["iterator"] }
-cw2 = "0.14.0"
-cw20 = "0.14.0"
-cw-storage-plus = "0.14.0"
-protobuf = { version = "3.1.0", features = ["with-bytes"] }
-schemars = "0.8.3"
-semver = "1.0.12"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-terraswap = { path = "../../../../packages/terraswap" }
-thiserror = "1.0.21"
-vault-network = { path = "../../../../packages/vault-network" }
-white-whale = { path = "../../../../packages/white-whale" }
+cosmwasm-std.workspace = true
+cw2.workspace = true
+cw20.workspace = true
+cw-storage-plus.workspace = true
+protobuf.workspace = true
+schemars.workspace = true
+semver.workspace = true
+serde.workspace = true
+terraswap.workspace = true
+thiserror.workspace = true
+vault-network.workspace = true
+white-whale.workspace = true
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.14.0"
-cw20-base = "0.14.0"
+cw-multi-test = "0.15.1"
+cw20-base = "0.15.1"
 vault = { path = "../vault" }
 fee_collector = { path = "../../fee_collector" }

--- a/contracts/liquidity_hub/vault-network/vault_router/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_router/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "vault_router"
 version = "1.0.0"
-authors = ["kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>"]
-edition = "2021"
+authors = [
+	"kaimen-sano <kaimen_sano@protonmail.com>, Kerber0x <kerber0x@protonmail.com>",
+]
+edition.workspace = true
 description = "Contract to facilitate flash-loans in the vault network"
-license = "MIT"
-repository = "https://github.com/White-Whale-DeFi-Platform/migaloo-core"
-homepage = "https://whitewhale.money"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 documentation = "https://whitewhale.money"
+publish.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -16,23 +19,23 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["iterator"] }
-cw2 = "0.14.0"
-cw20 = "0.14.0"
-cw-storage-plus = "0.14.0"
-protobuf = { version = "3.1.0", features = ["with-bytes"] }
-schemars = "0.8.3"
-semver = "1.0.12"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-terraswap = { path = "../../../../packages/terraswap" }
-thiserror = "1.0.21"
-vault-network = { path = "../../../../packages/vault-network" }
-white-whale = { path = "../../../../packages/white-whale" }
+cosmwasm-std.workspace = true
+cw2.workspace = true
+cw20.workspace = true
+cw-storage-plus.workspace = true
+protobuf.workspace = true
+schemars.workspace = true
+semver.workspace = true
+serde.workspace = true
+terraswap.workspace = true
+thiserror.workspace = true
+vault-network.workspace = true
+white-whale.workspace = true
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.14.0"
-cw20-base = "0.14.0"
+cw-multi-test = "0.15.1"
+cw20-base = "0.15.1"
 vault = { path = "../vault" }
 vault_factory = { path = "../vault_factory" }
 fee_collector = { path = "../../fee_collector" }

--- a/contracts/liquidity_hub/vault-network/vault_router/schema/execute_msg.json
+++ b/contracts/liquidity_hub/vault-network/vault_router/schema/execute_msg.json
@@ -304,7 +304,7 @@
       ]
     },
     "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
     },
     "Coin": {
@@ -373,43 +373,6 @@
           "additionalProperties": false
         },
         {
-          "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
-          "type": "object",
-          "required": [
-            "stargate"
-          ],
-          "properties": {
-            "stargate": {
-              "type": "object",
-              "required": [
-                "type_url",
-                "value"
-              ],
-              "properties": {
-                "type_url": {
-                  "type": "string"
-                },
-                "value": {
-                  "$ref": "#/definitions/Binary"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "ibc"
-          ],
-          "properties": {
-            "ibc": {
-              "$ref": "#/definitions/IbcMsg"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
           "type": "object",
           "required": [
             "wasm"
@@ -417,18 +380,6 @@
           "properties": {
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "gov"
-          ],
-          "properties": {
-            "gov": {
-              "$ref": "#/definitions/GovMsg"
             }
           },
           "additionalProperties": false
@@ -487,190 +438,6 @@
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object"
-    },
-    "GovMsg": {
-      "oneOf": [
-        {
-          "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
-          "type": "object",
-          "required": [
-            "vote"
-          ],
-          "properties": {
-            "vote": {
-              "type": "object",
-              "required": [
-                "proposal_id",
-                "vote"
-              ],
-              "properties": {
-                "proposal_id": {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                },
-                "vote": {
-                  "$ref": "#/definitions/VoteOption"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "IbcMsg": {
-      "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
-      "oneOf": [
-        {
-          "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
-          "type": "object",
-          "required": [
-            "transfer"
-          ],
-          "properties": {
-            "transfer": {
-              "type": "object",
-              "required": [
-                "amount",
-                "channel_id",
-                "timeout",
-                "to_address"
-              ],
-              "properties": {
-                "amount": {
-                  "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/Coin"
-                    }
-                  ]
-                },
-                "channel_id": {
-                  "description": "exisiting channel to send the tokens over",
-                  "type": "string"
-                },
-                "timeout": {
-                  "description": "when packet times out, measured on remote chain",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/IbcTimeout"
-                    }
-                  ]
-                },
-                "to_address": {
-                  "description": "address on the remote chain to receive these tokens",
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
-          "type": "object",
-          "required": [
-            "send_packet"
-          ],
-          "properties": {
-            "send_packet": {
-              "type": "object",
-              "required": [
-                "channel_id",
-                "data",
-                "timeout"
-              ],
-              "properties": {
-                "channel_id": {
-                  "type": "string"
-                },
-                "data": {
-                  "$ref": "#/definitions/Binary"
-                },
-                "timeout": {
-                  "description": "when packet times out, measured on remote chain",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/IbcTimeout"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
-          "type": "object",
-          "required": [
-            "close_channel"
-          ],
-          "properties": {
-            "close_channel": {
-              "type": "object",
-              "required": [
-                "channel_id"
-              ],
-              "properties": {
-                "channel_id": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "IbcTimeout": {
-      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
-      "type": "object",
-      "properties": {
-        "block": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/IbcTimeoutBlock"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "timestamp": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Timestamp"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "IbcTimeoutBlock": {
-      "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
-      "type": "object",
-      "required": [
-        "height",
-        "revision"
-      ],
-      "properties": {
-        "height": {
-          "description": "block height after which the packet times out. the height within the given revision",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "revision": {
-          "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      }
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
@@ -756,30 +523,9 @@
         }
       ]
     },
-    "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Uint64"
-        }
-      ]
-    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
-    },
-    "Uint64": {
-      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
-      "type": "string"
-    },
-    "VoteOption": {
-      "type": "string",
-      "enum": [
-        "yes",
-        "no",
-        "abstain",
-        "no_with_veto"
-      ]
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",

--- a/packages/terraswap/Cargo.toml
+++ b/packages/terraswap/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "terraswap"
 version = "2.8.0"
-authors = ["Terraform Labs, PTE.", "DELIGHT LABS", "Kerber0x <kerber0x@protonmail.com>"]
-edition = "2021"
+authors = [
+	"Terraform Labs, PTE.",
+	"DELIGHT LABS",
+	"Kerber0x <kerber0x@protonmail.com>",
+]
+edition.workspace = true
 description = "Common terraswap types"
 license = "Apache-2.0"
 repository = "https://github.com/terraswap/terraswap"
@@ -17,13 +21,13 @@ documentation = "https://docs.terraswap.io"
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.14.0" }
-cosmwasm-storage = { version = "1.0.0" }
-cosmwasm-std = { version = "1.0.0", features = ["stargate"] }
-schemars = "0.8.10"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-protobuf = { version = "2", features = ["with-bytes"] }
-white-whale = { version = "1.0.0", path = "../white-whale" }
+cw20.workspace = true
+cosmwasm-storage = "1.0.0"
+cosmwasm-std.workspace = true
+schemars.workspace = true
+serde.workspace = true
+protobuf.workspace = true
+white-whale.workspace = true
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/packages/vault-network/Cargo.toml
+++ b/packages/vault-network/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "vault-network"
 version = "1.0.0"
-edition = "2021"
+edition.workspace = true
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
 description = "Messages for the Vault Network"
-license = "MIT"
-repository = "https://github.com/White-Whale-DeFi-Platform/migaloo-core"
-homepage = "https://whitewhale.money"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 documentation = "https://whitewhale.money"
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-terraswap = { path = "../terraswap" }
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-schemars = "0.8.3"
-white-whale = { path = "../white-whale" }
+cosmwasm-std.workspace = true
+terraswap.workspace = true
+serde.workspace = true
+schemars.workspace = true
+white-whale.workspace = true

--- a/packages/white-whale/Cargo.toml
+++ b/packages/white-whale/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "white-whale"
 version = "1.0.0"
-edition = "2021"
+edition.workspace = true
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 description = "Common White Whale types and utils"
-license = "MIT"
-repository = "https://github.com/White-Whale-Defi-Platform/migaloo-core"
-homepage = "https://whitewhale.money"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 documentation = "https://whitewhale.money"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,7 +17,7 @@ documentation = "https://whitewhale.money"
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
+cosmwasm-std.workspace = true
 cosmwasm-bignumber = { git = "https://github.com/terra-money/terra-cosmwasm", branch = "feature/wasm-1.0" }
-schemars = "0.8.10"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+schemars.workspace = true
+serde.workspace = true


### PR DESCRIPTION
Uses the newly released Rust workspaces feature to manage the dependencies across the repository. Additionally, the `publish = false` flag is added to a few core contracts, as we do not want to upload contracts to crates.io

## Related Issues
Closes #84

Currently blocked by White-Whale-Defi-Platform/pool-network#12


---
## Checklist:

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.

_Note that Cargo is current complaining about a few 1.64 issues_