### PR TITLE
feat: add message to update pair config to pool factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "terraswap-factory"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-factory"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
 	"Terraform Labs, PTE.",
 	"DELIGHT LABS",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/schema/terraswap-factory.json
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/schema/terraswap-factory.json
@@ -78,6 +78,60 @@
         "additionalProperties": false
       },
       {
+        "description": "Updates a pair config",
+        "type": "object",
+        "required": [
+          "update_pair_config"
+        ],
+        "properties": {
+          "update_pair_config": {
+            "type": "object",
+            "required": [
+              "pair_addr"
+            ],
+            "properties": {
+              "feature_toggle": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/FeatureToggle"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "fee_collector_addr": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "owner": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pair_addr": {
+                "type": "string"
+              },
+              "pool_fees": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/PoolFee"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Instantiates pair contract",
         "type": "object",
         "required": [
@@ -241,6 +295,27 @@
       "Decimal": {
         "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
         "type": "string"
+      },
+      "FeatureToggle": {
+        "description": "Pool feature toggle",
+        "type": "object",
+        "required": [
+          "deposits_enabled",
+          "swaps_enabled",
+          "withdrawals_enabled"
+        ],
+        "properties": {
+          "deposits_enabled": {
+            "type": "boolean"
+          },
+          "swaps_enabled": {
+            "type": "boolean"
+          },
+          "withdrawals_enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
       },
       "Fee": {
         "type": "object",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
@@ -1,8 +1,10 @@
-use cosmwasm_std::{to_binary, CosmosMsg, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg};
+use cosmwasm_std::{
+    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg,
+};
 
 use terraswap::asset::AssetInfo;
 use terraswap::pair::{
-    InstantiateMsg as PairInstantiateMsg, MigrateMsg as PairMigrateMsg, PoolFee,
+    FeatureToggle, InstantiateMsg as PairInstantiateMsg, MigrateMsg as PairMigrateMsg, PoolFee,
 };
 use terraswap::querier::query_balance;
 
@@ -43,6 +45,29 @@ pub fn update_config(
     CONFIG.save(deps.storage, &config)?;
 
     Ok(Response::new().add_attribute("action", "update_config"))
+}
+
+/// Updates a pair config
+pub fn update_pair_config(
+    deps: DepsMut,
+    pair_addr: String,
+    owner: Option<String>,
+    fee_collector_addr: Option<String>,
+    pool_fees: Option<PoolFee>,
+    feature_toggle: Option<FeatureToggle>,
+) -> Result<Response, ContractError> {
+    Ok(Response::new()
+        .add_message(wasm_execute(
+            deps.api.addr_validate(pair_addr.as_str())?.to_string(),
+            &terraswap::pair::ExecuteMsg::UpdateConfig {
+                owner,
+                fee_collector_addr,
+                pool_fees,
+                feature_toggle,
+            },
+            vec![],
+        )?)
+        .add_attribute("action", "update_pair_config"))
 }
 
 /// Creates a Pair

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
@@ -73,6 +73,20 @@ pub fn execute(
         ExecuteMsg::MigratePair { contract, code_id } => {
             commands::execute_migrate_pair(deps, contract, code_id)
         }
+        ExecuteMsg::UpdatePairConfig {
+            pair_addr,
+            owner,
+            fee_collector_addr,
+            pool_fees,
+            feature_toggle,
+        } => commands::update_pair_config(
+            deps,
+            pair_addr,
+            owner,
+            fee_collector_addr,
+            pool_fees,
+            feature_toggle,
+        ),
     }
 }
 

--- a/packages/terraswap/src/factory.rs
+++ b/packages/terraswap/src/factory.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
 use crate::asset::{AssetInfo, PairInfo};
-use crate::pair::PoolFee;
+use crate::pair::{FeatureToggle, PoolFee};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -19,6 +19,14 @@ pub enum ExecuteMsg {
         fee_collector_addr: Option<String>,
         token_code_id: Option<u64>,
         pair_code_id: Option<u64>,
+    },
+    /// Updates a pair config
+    UpdatePairConfig {
+        pair_addr: String,
+        owner: Option<String>,
+        fee_collector_addr: Option<String>,
+        pool_fees: Option<PoolFee>,
+        feature_toggle: Option<FeatureToggle>,
     },
     /// Instantiates pair contract
     CreatePair {


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This adds the possibility to update a pair config from the factory, which is the only way to do it since only the owner of a pair can perform this action.

Did integration tests directly on testnet.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
