### PR TITLE
Docs/fix codeowner and update security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-# The person below is the repository administrator who ensures compliance with the White Whale Repository Guideline.
-* @kerber0x
+# @kerber0x is the repository administrator who ensures compliance with the White Whale Repository Guideline.
+# The remaining code owners help maintain the repository.
+* @kerber0x @0xFable @kaimen-sano @Sen-Com
 
-# The following contributors help maintain the repository.
-* @0xFable @kaimen-sano @Sen-Com

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,7 +7,7 @@ This document outlines security procedures and general policies for the `migaloo
 ## Reporting a Bug
 Security is something we take seriously at White Whale. Thanks for taking the time to improve the security of `migaloo-frontend`. We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Please report security bugs by emailing White Whale's CTO at sencommunis@protonmail.com or the head of smart contracts at kerber0x@protonmail.com. Do not report it publicly on the GitHub issues tracker. Your report should detail the necessary steps to reproduce the security issue. We will acknowledge your email within 48 hours and send a detailed response indicating the next steps. After the initial reply to your report, we will keep you informed of the progress towards a fix and full announcement and may ask for additional information or guidance.
+Please report security bugs by emailing White Whale at security@whitewhale.money. Do not report it publicly on the GitHub issues tracker. Your report should detail the necessary steps to reproduce the security issue. We will acknowledge your email within 48 hours and send a detailed response indicating the next steps. After the initial reply to your report, we will keep you informed of the progress towards a fix and full announcement and may ask for additional information or guidance.
 
 Report security bugs in third-party modules to the person or team maintaining the module.
 


### PR DESCRIPTION
## Description and Motivation
This PR adds @kerber0x back to the code owners and replaces all security contacts with the new White Whale security email. 

## Related Issues
None

---

## Checklist:
- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
