### PR TITLE
fix: remove pair message fix on pool factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "terraswap-factory"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-factory"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
 	"Terraform Labs, PTE.",
 	"DELIGHT LABS",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/schema/terraswap-factory.json
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/schema/terraswap-factory.json
@@ -222,7 +222,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Removes pair",
+        "description": "Removes pair contract given asset infos",
         "type": "object",
         "required": [
           "remove_pair"
@@ -231,11 +231,16 @@
           "remove_pair": {
             "type": "object",
             "required": [
-              "pair_address"
+              "asset_infos"
             ],
             "properties": {
-              "pair_address": {
-                "type": "string"
+              "asset_infos": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/AssetInfo"
+                },
+                "maxItems": 2,
+                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
@@ -66,7 +66,7 @@ pub fn execute(
             asset_infos,
             pool_fees,
         } => commands::create_pair(deps, env, asset_infos, pool_fees),
-        ExecuteMsg::RemovePair { pair_address } => commands::remove_pair(deps, env, pair_address),
+        ExecuteMsg::RemovePair { asset_infos } => commands::remove_pair(deps, env, asset_infos),
         ExecuteMsg::AddNativeTokenDecimals { denom, decimals } => {
             commands::add_native_token_decimals(deps, env, denom, decimals)
         }

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/testing.rs
@@ -1119,7 +1119,7 @@ fn delete_pair() {
             &pair_key_vec,
             &PairInfoRaw {
                 liquidity_token: CanonicalAddr(cosmwasm_std::Binary(vec![])),
-                contract_addr: CanonicalAddr(cosmwasm_std::Binary(vec![])),
+                contract_addr: deps.api.addr_canonicalize("pair0000").unwrap(),
                 asset_infos: raw_infos,
                 asset_decimals: [6, 6],
             },
@@ -1130,9 +1130,7 @@ fn delete_pair() {
 
     assert!(pair.is_ok(), "pair key should exist");
 
-    let msg = ExecuteMsg::RemovePair {
-        pair_address: String::from_utf8(pair_key_vec.clone()).unwrap(),
-    };
+    let msg = ExecuteMsg::RemovePair { asset_infos };
     let env = mock_env();
     let info = mock_info("addr0000", &[]);
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
@@ -1141,10 +1139,7 @@ fn delete_pair() {
         res.attributes,
         vec![
             attr("action", "remove_pair"),
-            attr(
-                "pair_contract_addr",
-                String::from_utf8(pair_key_vec.clone()).unwrap(),
-            ),
+            attr("pair_contract_addr", "pair0000",),
         ]
     );
 
@@ -1168,16 +1163,7 @@ fn delete_pair_failed_if_not_found() {
         },
     ];
 
-    let raw_infos = [
-        asset_infos[0].to_raw(&deps.api).unwrap(),
-        asset_infos[1].to_raw(&deps.api).unwrap(),
-    ];
-
-    let pair_key_vec = pair_key(&raw_infos);
-
-    let msg = ExecuteMsg::RemovePair {
-        pair_address: String::from_utf8(pair_key_vec.clone()).unwrap(),
-    };
+    let msg = ExecuteMsg::RemovePair { asset_infos };
     let env = mock_env();
     let info = mock_info("addr0000", &[]);
     let res = execute(deps.as_mut(), env, info, msg);

--- a/packages/terraswap/src/factory.rs
+++ b/packages/terraswap/src/factory.rs
@@ -41,8 +41,8 @@ pub enum ExecuteMsg {
         contract: String,
         code_id: Option<u64>,
     },
-    /// Removes pair
-    RemovePair { pair_address: String },
+    /// Removes pair contract given asset infos
+    RemovePair { asset_infos: [AssetInfo; 2] },
 }
 
 #[cw_serde]


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR fixes broken remove pair message from the pool factory, preventing from effectively removing an existing pair.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
