### PR TITLE
ci: add burn fee to vault and pool deployment scripts

### DIFF
--- a/scripts/deployment/deploy_pool.sh
+++ b/scripts/deployment/deploy_pool.sh
@@ -21,6 +21,7 @@ function display_usage() {
 #{
 #  "protocol_fee": "0.001",
 #  "swap_fee": "0.002",
+#  "burn_fee": "0.002",
 #  "assets": [
 #    {
 #      "asset": "uluna",
@@ -43,6 +44,7 @@ function read_pool_config() {
   mapfile -t assets < <(jq -c '.assets[]' <$pool)
   protocol_fee=$(jq -r '.protocol_fee' $pool)
   swap_fee=$(jq -r '.swap_fee' $pool)
+  burn_fee=$(jq -r '.burn_fee' $pool)
 }
 
 function check_decimals() {
@@ -90,13 +92,14 @@ function create_pool() {
     asset_infos+=($asset_info)
   done
 
-  create_pool_msg='{"create_pair":{"asset_infos":['${asset_infos[0]}','${asset_infos[1]}'],"pool_fees":{"protocol_fee":{"share":"'$protocol_fee'"},"swap_fee":{"share":"'$swap_fee'"}}}}'
+  create_pool_msg='{"create_pair":{"asset_infos":['${asset_infos[0]}','${asset_infos[1]}'],"pool_fees":{"protocol_fee":{"share":"'$protocol_fee'"},"burn_fee":{"share":"'$burn_fee'"},"swap_fee":{"share":"'$swap_fee'"}}}}'
 
   echo "Creating pool with the following configuration:"
   echo "Asset 0: ${asset_infos[0]}"
   echo "Asset 1: ${asset_infos[1]}"
   echo "Protocol fee: $protocol_fee"
   echo -e "Swap fee: $swap_fee\n"
+  echo -e "Burn fee: $burn_fee\n"
 
   local res=$($BINARY tx wasm execute $pool_factory_addr "$create_pool_msg" $TXFLAG --from $deployer_address)
   echo $res

--- a/scripts/deployment/deploy_vault.sh
+++ b/scripts/deployment/deploy_vault.sh
@@ -21,6 +21,7 @@ function display_usage() {
 #  "asset": "ujuno", //or contract
 #  "protocol_fee": "0.01",
 #  "flash_loan_fee": "0.02",
+#  "burn_fee": "0.02",
 #  "is_native": true //or false
 # }
 #
@@ -35,6 +36,7 @@ function read_vault_config() {
   asset=$(jq -r '.asset' $vault)
   protocol_fee=$(jq -r '.protocol_fee' $vault)
   flash_loan_fee=$(jq -r '.flash_loan_fee' $vault)
+  burn_fee=$(jq -r '.burn_fee' $vault)
   is_native=$(jq -r '.is_native' $vault)
 }
 
@@ -56,12 +58,13 @@ function create_vault() {
     asset_info='{"token":{"contract_addr":"'$asset'"}}'
   fi
 
-  create_vault_msg='{"create_vault":{"asset_info":'$asset_info',"fees":{"protocol_fee":{"share":"'$protocol_fee'"},"flash_loan_fee":{"share":"'$flash_loan_fee'"}}}}'
+  create_vault_msg='{"create_vault":{"asset_info":'$asset_info',"fees":{"protocol_fee":{"share":"'$protocol_fee'"},"burn_fee":{"share":"'$burn_fee'"},"flash_loan_fee":{"share":"'$flash_loan_fee'"}}}}'
 
   echo "Creating vault with the following configuration:"
   echo "Asset: $asset"
   echo "Protocol fee: $protocol_fee"
   echo -e "Flash loan fee: $flash_loan_fee\n"
+  echo -e "Burn fee: $burn_fee\n"
 
   local res=$($BINARY tx wasm execute $vault_factory_addr "$create_vault_msg" $TXFLAG --from $deployer_address)
   echo $res


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

Creating pools and vaults require providing a burn fee now. This PR fixes that on the deployment scripts. 

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
